### PR TITLE
Fix a bug because of a renamed function for LOVE 11

### DIFF
--- a/pong-1/push.lua
+++ b/pong-1/push.lua
@@ -98,7 +98,7 @@ function push:setShader(name, shader)
 end
 
 function push:initValues()
-  self._PSCALE = self._highdpi and love.window.getPixelScale() or 1
+  self._PSCALE = self._highdpi and love.window.getDPIScale() or 1
   
   self._SCALE = {
     x = self._RWIDTH/self._WWIDTH * self._PSCALE,


### PR DESCRIPTION
I have received an error on LOVE 11 for Windows 10.  It says that `love.window.getPixelScale` is nil, so I fixed it.