### PR TITLE
Fix the flipped dx and dy

### DIFF
--- a/pong-10/Ball.lua
+++ b/pong-10/Ball.lua
@@ -22,8 +22,8 @@ function Ball:init(x, y, width, height)
 
     -- these variables are for keeping track of our velocity on both the
     -- X and Y axis, since the ball can move in two dimensions
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
 end
 
 --[[
@@ -54,8 +54,8 @@ end
 function Ball:reset()
     self.x = VIRTUAL_WIDTH / 2 - 2
     self.y = VIRTUAL_HEIGHT / 2 - 2
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[

--- a/pong-11/Ball.lua
+++ b/pong-11/Ball.lua
@@ -22,8 +22,8 @@ function Ball:init(x, y, width, height)
 
     -- these variables are for keeping track of our velocity on both the
     -- X and Y axis, since the ball can move in two dimensions
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
 end
 
 --[[
@@ -54,8 +54,8 @@ end
 function Ball:reset()
     self.x = VIRTUAL_WIDTH / 2 - 2
     self.y = VIRTUAL_HEIGHT / 2 - 2
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[

--- a/pong-12/Ball.lua
+++ b/pong-12/Ball.lua
@@ -22,8 +22,8 @@ function Ball:init(x, y, width, height)
 
     -- these variables are for keeping track of our velocity on both the
     -- X and Y axis, since the ball can move in two dimensions
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
 end
 
 --[[
@@ -54,8 +54,8 @@ end
 function Ball:reset()
     self.x = VIRTUAL_WIDTH / 2 - 2
     self.y = VIRTUAL_HEIGHT / 2 - 2
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[

--- a/pong-5/Ball.lua
+++ b/pong-5/Ball.lua
@@ -22,8 +22,8 @@ function Ball:init(x, y, width, height)
 
     -- these variables are for keeping track of our velocity on both the
     -- X and Y axis, since the ball can move in two dimensions
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[
@@ -33,8 +33,8 @@ end
 function Ball:reset()
     self.x = VIRTUAL_WIDTH / 2 - 2
     self.y = VIRTUAL_HEIGHT / 2 - 2
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[

--- a/pong-6/Ball.lua
+++ b/pong-6/Ball.lua
@@ -22,8 +22,8 @@ function Ball:init(x, y, width, height)
 
     -- these variables are for keeping track of our velocity on both the
     -- X and Y axis, since the ball can move in two dimensions
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[
@@ -54,8 +54,8 @@ end
 function Ball:reset()
     self.x = VIRTUAL_WIDTH / 2 - 2
     self.y = VIRTUAL_HEIGHT / 2 - 2
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[

--- a/pong-7/Ball.lua
+++ b/pong-7/Ball.lua
@@ -22,8 +22,8 @@ function Ball:init(x, y, width, height)
 
     -- these variables are for keeping track of our velocity on both the
     -- X and Y axis, since the ball can move in two dimensions
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
 end
 
 --[[
@@ -54,8 +54,8 @@ end
 function Ball:reset()
     self.x = VIRTUAL_WIDTH / 2 - 2
     self.y = VIRTUAL_HEIGHT / 2 - 2
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[

--- a/pong-8/Ball.lua
+++ b/pong-8/Ball.lua
@@ -22,8 +22,8 @@ function Ball:init(x, y, width, height)
 
     -- these variables are for keeping track of our velocity on both the
     -- X and Y axis, since the ball can move in two dimensions
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
 end
 
 --[[
@@ -54,8 +54,8 @@ end
 function Ball:reset()
     self.x = VIRTUAL_WIDTH / 2 - 2
     self.y = VIRTUAL_HEIGHT / 2 - 2
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[

--- a/pong-9/Ball.lua
+++ b/pong-9/Ball.lua
@@ -22,8 +22,8 @@ function Ball:init(x, y, width, height)
 
     -- these variables are for keeping track of our velocity on both the
     -- X and Y axis, since the ball can move in two dimensions
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(2) == 1 and math.random(-80, -100) or math.random(80, 100)
 end
 
 --[[
@@ -54,8 +54,8 @@ end
 function Ball:reset()
     self.x = VIRTUAL_WIDTH / 2 - 2
     self.y = VIRTUAL_HEIGHT / 2 - 2
-    self.dy = math.random(2) == 1 and -100 or 100
-    self.dx = math.random(-50, 50)
+    self.dx = math.random(2) == 1 and -100 or 100
+    self.dy = math.random(-50, 50)
 end
 
 --[[


### PR DESCRIPTION
During the class refactor of pong, the dx and dy init and reset operations were inadvertently swapped. Once collision with the wall was introduced in pong-7, this was less of an issue; for anyone trying the code in pong-5 or pong-6, the balls never reach the paddles.